### PR TITLE
append showing the list of slashes to the validator command series

### DIFF
--- a/cmd/constants/constants.go
+++ b/cmd/constants/constants.go
@@ -22,6 +22,7 @@ const (
 	WOASFlag      = "woas"
 	SOASFlag      = "soas"
 	NextEpochFlag = "next-epoch"
+	BackEpochFlag = "back-epoch"
 
 	// Hub-Layer(L1)
 	MainnetRPC     = "https://rpc.mainnet.oasys.games/"

--- a/cmd/validator/infoSlash.go
+++ b/cmd/validator/infoSlash.go
@@ -1,0 +1,102 @@
+package validator
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	"github.com/oasysgames/oasys-pos-cli/cmd/constants"
+	cmdutils "github.com/oasysgames/oasys-pos-cli/cmd/utils"
+	"github.com/oasysgames/oasys-pos-cli/contracts"
+	"github.com/oasysgames/oasys-pos-cli/utils"
+)
+
+const MAX_BACk_EPOCH = 1024
+
+var infoSlashCmd = &cobra.Command{
+	Use:   cmdPrefix + "info-slash",
+	Short: "List of the number of slashings occurred in each recent epoch",
+	Run: func(cmd *cobra.Command, args []string) {
+		var validator common.Address
+		if s, err := cmd.Flags().GetString(constants.ValidatorFlag); err != nil {
+			utils.Fatal(err)
+		} else if s != "" {
+			validator = common.HexToAddress(s)
+		} else {
+			if wallet, err := cmdutils.NewEthWallet(cmd); err == nil {
+				validator = wallet.From
+			}
+		}
+
+		ec, err := cmdutils.NewEthClient(cmd)
+		if err != nil {
+			utils.Fatal(err)
+		}
+
+		backEpoch, err := cmd.Flags().GetUint16(constants.BackEpochFlag)
+		if err != nil {
+			utils.Fatal(err)
+		}
+
+		if backEpoch > MAX_BACk_EPOCH {
+			utils.Fatal(fmt.Errorf("back-epoch must be less than or equal to %d", MAX_BACk_EPOCH))
+		}
+
+		doInfoSlash(ec, validator, backEpoch)
+	},
+}
+
+func doInfoSlash(ec *ethclient.Client, validator common.Address, backEpoch uint16) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(constants.RpcTimeout))
+	defer cancel()
+
+	callOpts := &bind.CallOpts{Context: ctx}
+
+	environment, err := contracts.NewEnvironment(ec)
+	if err != nil {
+		utils.Fatal(err)
+	}
+
+	stakemanager, err := contracts.NewStakeManager(ec)
+	if err != nil {
+		utils.Fatal(err)
+	}
+
+	currentEpoch, err := environment.Epoch(callOpts)
+	if err != nil {
+		utils.Fatal(err)
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAutoFormatHeaders(false)
+	table.SetHeader([]string{
+		"ID",
+		"Epoch",
+		"Slash",
+	})
+
+	epoch := big.NewInt(0)
+	for i := int(backEpoch) - 1; 0 <= i; i-- {
+		epoch.Sub(currentEpoch, big.NewInt(int64(i)))
+		result, err := stakemanager.GetBlockAndSlashes(callOpts, validator, epoch)
+		if err != nil {
+			utils.Fatal(err)
+		}
+
+		table.Append([]string{
+			fmt.Sprintf("%d", int(backEpoch)-i),
+			fmt.Sprintf("%d", epoch),
+			fmt.Sprintf("%s", result.Slashes.String()),
+		})
+	}
+
+	table.Render()
+}

--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -15,6 +15,7 @@ var (
 	commands = []*cobra.Command{
 		joinCmd,
 		infoCmd,
+		infoSlashCmd,
 		infoAllCmd,
 		activateCmd,
 		deactivateCmd,
@@ -40,6 +41,11 @@ func AddCommand(rootCmd *cobra.Command) {
 	// validator:info
 	rootCmd.AddCommand(infoCmd)
 	infoCmd.Flags().String(constants.ValidatorFlag, "", "Address of the validator owner. Default is transaction sender.")
+
+	// validator:info-slash
+	rootCmd.AddCommand(infoSlashCmd)
+	infoSlashCmd.Flags().String(constants.ValidatorFlag, "", "Address of the validator owner. Default is transaction sender.")
+	infoSlashCmd.Flags().Uint16(constants.BackEpochFlag, 10, "This flag determines the number of epochs to go back in order to start listing slashes., with a maximum value of 1024.")
 
 	// validator:info-all
 	rootCmd.AddCommand(infoAllCmd)


### PR DESCRIPTION
To retrieve the list of slashes, newly added the `validator:info-slash` command,
How did i checked
```sh
./oaspos validator:info-slash --validator 0xa505014a84e8bdc4a620470a53ead872b0c1ca5b --network mainnet
+----+-------+-------+
| ID | Epoch | Slash |
+----+-------+-------+
|  1 |   284 |     0 |
|  2 |   285 |     0 |
|  3 |   286 |     0 |
|  4 |   287 |     0 |
|  5 |   288 |     0 |
|  6 |   289 |     0 |
|  7 |   290 |     0 |
|  8 |   291 |     3 |
|  9 |   292 |     0 |
| 10 |   293 |     3 |
+----+-------+-------+
```